### PR TITLE
Fixing issues reported on PR #831

### DIFF
--- a/io.catenax.material.certificate_of_analysis/1.0.0/CertificateOfAnalysis.ttl
+++ b/io.catenax.material.certificate_of_analysis/1.0.0/CertificateOfAnalysis.ttl
@@ -13,6 +13,8 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
+
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -74,7 +76,7 @@
 :CertificateOfAnalysisAbstractEntity a samm:AbstractEntity ;
    samm:preferredName "Certificate Of Analysis Abstract Entity"@en ;
    samm:description "Represents the certificate of analysis document usually supplied via paper or digitally as PDF"@en ;
-   samm:properties ( [ samm:property :issueDateProperty; samm:optional true; samm:payloadName "issueDate" ] [ samm:property :issueVersion; samm:optional true ] :languageProperty ) .
+   samm:properties ( [ samm:property :issueDate; samm:optional true; samm:payloadName "issueDate" ] [ samm:property :issueVersion; samm:optional true ] :language ) .
 
 :link a samm:Property ;
    samm:preferredName "link"@en ;
@@ -109,7 +111,7 @@
    samm:description "Base64-encoded string of data according to format"@en ;
    samm:characteristic :PayloadPreFormattedCharacteristic .
 
-:issueDateProperty a samm:Property ;
+:issueDate a samm:Property ;
    samm:preferredName "issue date"@en ;
    samm:description "Issue date of Certificate of Analysis"@en ;
    samm:characteristic :IssueDateCharacteristic ;
@@ -121,7 +123,7 @@
    samm:characteristic samm-c:Text ;
    samm:exampleValue "8.1" .
 
-:languageProperty a samm:Property ;
+:language a samm:Property ;
    samm:preferredName "language"@en ;
    samm:description "ISO-639-1 code of language"@en ;
    samm:characteristic samm-c:Language ;

--- a/io.catenax.material.chemical_material_passport/3.0.0/ChemicalMaterialPassport.ttl
+++ b/io.catenax.material.chemical_material_passport/3.0.0/ChemicalMaterialPassport.ttl
@@ -28,7 +28,7 @@
 @prefix : <urn:samm:io.catenax.material.chemical_material_passport:3.0.0#> .
 @prefix ext-analysis: <urn:samm:io.catenax.material.certificate_of_analysis:1.0.0#> .
 @prefix ext-information: <urn:samm:io.catenax.material.technical_information:1.0.0#> .
-@prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:5.0.0#> .
+@prefix ext-passport: <urn:samm:io.catenax.generic.digital_product_passport:6.0.0#> .
 @prefix ext-quantity: <urn:samm:io.catenax.shared.quantity:2.0.0#> .
 @prefix ext-sheet: <urn:samm:io.catenax.material.safety_data_sheet:1.0.0#> .
 
@@ -108,10 +108,12 @@
 
 :complianceDocumentation a samm:Property ;
    samm:preferredName "compliance documentation"@en ;
+   samm:description "Refers to the collection of documents that provide information and evidence that an organization is operating within the legal and regulatory frameworks applicable to the chemical industry."@en ;
    samm:characteristic :ComplianceDocumentationCharacteristic .
 
 :safetyDataSheetDocumentation a samm:Property ;
    samm:preferredName "Safety Data Sheet Documentation"@en ;
+   samm:description "Refers to the collection of documents that provide information on the hazards associated with the material, as well as guidelines for its safe handling, storage, and disposal."@en ;
    samm:characteristic :SafetyDataSheetDocumentationCharacteristic .
 
 :ParameterCharacteristic a samm:Characteristic ;
@@ -190,7 +192,7 @@
 
 :ComplianceDocumentationEntity a samm:Entity ;
    samm:preferredName "Compliance Documentation Entity"@en ;
-   samm:properties ( [ samm:property ext-analysis:hasCertificateOfAnalysisSheetPreFormatted; samm:optional true ] [ samm:property ext-analysis:hasCertificateOfAnalysisBinary; samm:optional true ] [ samm:property ext-analysis:hasCertificateOfAnalysisLink; samm:optional true ] [ samm:property ext-information:technicalInformationLinkProperty; samm:optional true; samm:payloadName "hasTechnicalInformationLink" ] [ samm:property ext-information:technicalInformationBinaryProperty; samm:optional true; samm:payloadName "hasTechnicalInformationBinary" ] ) .
+   samm:properties ( [ samm:property ext-analysis:hasCertificateOfAnalysisSheetPreFormatted; samm:optional true ] [ samm:property ext-analysis:hasCertificateOfAnalysisBinary; samm:optional true ] [ samm:property ext-analysis:hasCertificateOfAnalysisLink; samm:optional true ] [ samm:property ext-information:technicalInformationLink; samm:optional true; samm:payloadName "hasTechnicalInformationLink" ] [ samm:property ext-information:technicalInformationBinary; samm:optional true; samm:payloadName "hasTechnicalInformationBinary" ] ) .
 
 :SafetyDataSheetDocumentationEntity a samm:Entity ;
    samm:preferredName "Safety Data Sheet Documentation Entity"@en ;

--- a/io.catenax.material.safety_data_sheet/1.0.0/SafetyDataSheet.ttl
+++ b/io.catenax.material.safety_data_sheet/1.0.0/SafetyDataSheet.ttl
@@ -13,6 +13,8 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
+
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -74,7 +76,7 @@
 :SafetyDataSheetAbstractEntity a samm:AbstractEntity ;
    samm:preferredName "safety data sheet"@en ;
    samm:description "Chemical products are supplied with a \"Safety Data Sheet\" (SDS) which is a document structured in 16 internationally agreed sections usually supplied via paper or digitally as PDF. A SDS lists information relating to occupational safety and health for the use of various substances and products."@en ;
-   samm:properties ( [ samm:property :issueVersion; samm:optional true ] [ samm:property :previousVersion; samm:optional true ] :language :applicableToCountryProperty [ samm:property :issueDate; samm:optional true ] ) .
+   samm:properties ( [ samm:property :issueVersion; samm:optional true ] [ samm:property :previousVersion; samm:optional true ] :language :applicableToCountry [ samm:property :issueDate; samm:optional true ] ) .
 
 :link a samm:Property ;
    samm:preferredName "link"@en ;
@@ -130,7 +132,7 @@
    samm:characteristic samm-c:Language ;
    samm:exampleValue "de" .
 
-:applicableToCountryProperty a samm:Property ;
+:applicableToCountry a samm:Property ;
    samm:preferredName "applies to country"@en ;
    samm:description "Relationship between the Safety Data Sheet and the country to which it applies for."@en ;
    samm:characteristic :CountryTrait .
@@ -171,15 +173,15 @@
 :SDSCountryEntity a samm:Entity ;
    samm:preferredName "country"@en ;
    samm:description "A country is a distinct territorial body or political entity."@en ;
-   samm:properties ( [ samm:property :hasAlpha3CodeProperty; samm:payloadName "alpha3Code" ] [ samm:property :labelProperty; samm:payloadName "name" ] ) .
+   samm:properties ( [ samm:property :hasAlpha3Code; samm:payloadName "alpha3Code" ] [ samm:property :label; samm:payloadName "name" ] ) .
 
-:hasAlpha3CodeProperty a samm:Property ;
+:hasAlpha3Code a samm:Property ;
    samm:preferredName "has alpha3 code"@en ;
    samm:description "Country code consisting of three capital letters according to ISO 3166."@en ;
    samm:characteristic :Alpha3CodeTrait ;
    samm:exampleValue "DEU" .
 
-:labelProperty a samm:Property ;
+:label a samm:Property ;
    samm:preferredName "label"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Germany" .

--- a/io.catenax.material.technical_information/1.0.0/TechnicalInformation.ttl
+++ b/io.catenax.material.technical_information/1.0.0/TechnicalInformation.ttl
@@ -13,6 +13,8 @@
 # SPDX-License-Identifier: CC-BY-4.0
 #######################################################################
 
+
+
 @prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
 @prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
 @prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.1.0#> .
@@ -25,15 +27,15 @@
 :TechnicalInformation a samm:Aspect ;
    samm:preferredName "Technical Information Model"@en ;
    samm:description "Model that represents the Technical Information of Chemical Materials."@en ;
-   samm:properties ( [ samm:property :technicalInformationLinkProperty; samm:payloadName "technicalInformationLink" ] [ samm:property :technicalInformationBinaryProperty; samm:payloadName "technicalInformationBinary" ] ) ;
+   samm:properties ( [ samm:property :technicalInformationLink; samm:payloadName "technicalInformationLink" ] [ samm:property :technicalInformationBinary; samm:payloadName "technicalInformationBinary" ] ) ;
    samm:operations ( ) ;
    samm:events ( ) .
 
-:technicalInformationLinkProperty a samm:Property ;
+:technicalInformationLink a samm:Property ;
    samm:preferredName "technical information link"@en ;
    samm:characteristic :TechnicalInformationCharacteristicList .
 
-:technicalInformationBinaryProperty a samm:Property ;
+:technicalInformationBinary a samm:Property ;
    samm:preferredName "technical information binary"@en ;
    samm:characteristic :TechnicalInformationBinaryCharacteristicList .
 
@@ -48,46 +50,46 @@
 :TechnicalInformationLinkEntity a samm:Entity ;
    samm:extends :TechnicalInformationAbstractEntity ;
    samm:preferredName "technical information link"@en ;
-   samm:properties ( [ samm:property :linkProperty; samm:payloadName "link" ] ) .
+   samm:properties ( [ samm:property :link; samm:payloadName "link" ] ) .
 
 :TechnicalInformationBinaryEntity a samm:Entity ;
    samm:extends :TechnicalInformationAbstractEntity ;
    samm:preferredName "technical information binary"@en ;
-   samm:properties ( [ samm:property :payloadProperty; samm:payloadName "payload" ] ) .
+   samm:properties ( [ samm:property :payload; samm:payloadName "payload" ] ) .
 
 :TechnicalInformationAbstractEntity a samm:AbstractEntity ;
    samm:preferredName "technical information"@en ;
    samm:description "Represents the Technical Information document usually supplied via paper or digitally as PDF"@en ;
-   samm:properties ( [ samm:property :issueVersionProperty; samm:optional true; samm:payloadName "issueVersion" ] [ samm:property :appliesToCountryProperty; samm:payloadName "country" ] [ samm:property :issueDateProperty; samm:optional true; samm:payloadName "issueDate" ] [ samm:property :languageProperty; samm:payloadName "language" ] ) .
+   samm:properties ( [ samm:property :issueVersion; samm:optional true; samm:payloadName "issueVersion" ] [ samm:property :appliesToCountry; samm:payloadName "country" ] [ samm:property :issueDate; samm:optional true; samm:payloadName "issueDate" ] [ samm:property :language; samm:payloadName "language" ] ) .
 
-:linkProperty a samm:Property ;
+:link a samm:Property ;
    samm:preferredName "link"@en ;
    samm:description "HTTP(S) address according to RFC 3986"@en ;
    samm:characteristic samm-c:ResourcePath ;
    samm:exampleValue "https://www.company.com/sds/240242892.pdf"^^xsd:anyURI .
 
-:payloadProperty a samm:Property ;
+:payload a samm:Property ;
    samm:preferredName "payload"@en ;
    samm:description "Base64-encoded string of PDF file"@en ;
    samm:characteristic :PayloadCharacteristic .
 
-:issueVersionProperty a samm:Property ;
+:issueVersion a samm:Property ;
    samm:preferredName "issue version"@en ;
    samm:description "Versioning information of the Technical Information"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "8.1" .
 
-:appliesToCountryProperty a samm:Property ;
+:appliesToCountry a samm:Property ;
    samm:preferredName "applies to country"@en ;
    samm:characteristic :CountryTrait .
 
-:issueDateProperty a samm:Property ;
+:issueDate a samm:Property ;
    samm:preferredName "issue date"@en ;
    samm:description "Issue date of Technical Information"@en ;
    samm:characteristic :IssueDateCharacteristic ;
    samm:exampleValue "2023-03-28"^^xsd:date .
 
-:languageProperty a samm:Property ;
+:language a samm:Property ;
    samm:preferredName "language"@en ;
    samm:description "ISO-639-2/B code of language"@en ;
    samm:characteristic samm-c:Text ;
@@ -119,15 +121,15 @@
 :CountryEntity a samm:Entity ;
    samm:preferredName "country"@en ;
    samm:description "A country is a distinct territorial body or political entity."@en ;
-   samm:properties ( [ samm:property :hasAlpha3CodeProperty; samm:payloadName "alpha3Code" ] [ samm:property :labelProperty; samm:payloadName "name" ] ) .
+   samm:properties ( [ samm:property :hasAlpha3Code; samm:payloadName "alpha3Code" ] [ samm:property :label; samm:payloadName "name" ] ) .
 
-:hasAlpha3CodeProperty a samm:Property ;
+:hasAlpha3Code a samm:Property ;
    samm:preferredName "has alpha3 code"@en ;
    samm:description "Country code consisting of three capital letters according to ISO 3166."@en ;
    samm:characteristic :Alpha3CodeTrait ;
    samm:exampleValue "DEU" .
 
-:labelProperty a samm:Property ;
+:label a samm:Property ;
    samm:preferredName "label"@en ;
    samm:characteristic samm-c:Text ;
    samm:exampleValue "Germany" .
@@ -145,5 +147,5 @@
 :ISO3166CodeConstraint a samm-c:RegularExpressionConstraint ;
    samm:preferredName "ISO 3166 code constraint"@en ;
    samm:description "Constrainst the value to only three capital letters to represent the country code according to ISO 3166."@en ;
-   samm:value " ^[A-Z][A-Z][A-Z]" .
+   samm:value "^[A-Z][A-Z][A-Z]" .
 


### PR DESCRIPTION
This commit includes:

-  missing descriptions and removal of word "Property" from all properties of models. 
-  refined Regex on ISO Code of countries as empty space crashes the JSON validation (in some validators)
-  reuse of the Generic Digital Passport latest version (version [6.0.0](https://github.com/eclipse-tractusx/sldt-semantic-models/tree/main/io.catenax.generic.digital_product_passport/6.0.0) was released on April 24) 

